### PR TITLE
[RFC] Append repeated fields

### DIFF
--- a/jilutil/__init__.py
+++ b/jilutil/__init__.py
@@ -6,7 +6,7 @@ import csv
 import os
 from datetime import datetime
 
-from jil_parser import JilParser
+from .jil_parser import JilParser
 from jilutil.auto_sys_job import AutoSysJob
 
 verbose = False

--- a/jilutil/auto_sys_job.py
+++ b/jilutil/auto_sys_job.py
@@ -89,9 +89,24 @@ class AutoSysJob(UserDict):
 
     @classmethod
     def from_str(cls, jil: str):
-        """Creates a new job from a string"""
+        r"""Creates a new AutoSysJob from a string
+
+        ```pycon
+        >>> AutoSysJob.from_str('')
+        {'insert_job': ''}
+        >>> AutoSysJob.from_str(None)
+        {'insert_job': ''}
+        >>> AutoSysJob.from_str('insert_job: TEST.ECHO   job_type: BOX \n')
+        {'insert_job': 'TEST.ECHO', 'job_type': 'BOX'}
+        >>> AutoSysJob.from_str('insert_job: TEST.ECHO \n repeated_field: value \n repeated_field: value')
+        {'insert_job': 'TEST.ECHO', 'repeated_field': ['value', 'value']}
         
+        ```
+        """
         job = cls()
+
+        if not jil:
+            return job
 
         # force job_type onto a new line
         jil = jil.replace('job_type', '\njob_type', 1)

--- a/jilutil/auto_sys_job.py
+++ b/jilutil/auto_sys_job.py
@@ -75,9 +75,8 @@ class AutoSysJob(UserDict):
         job_str = self.job_name_comment.format(atts['insert_job']) + '\n\n'
 
         # add special insert_job & job_type attributes
-        job_str += 'insert_job: {}   job_type: {}\n'.format(atts['insert_job'], atts['job_type'])
+        job_str += 'insert_job: {}'.format(atts['insert_job'])
         del atts['insert_job']
-        del atts['job_type']
 
         # iterate over attribute:value pairs in alphabetical order
         for attribute, value in sorted(atts.items()):

--- a/jilutil/auto_sys_job.py
+++ b/jilutil/auto_sys_job.py
@@ -122,11 +122,12 @@ class AutoSysJob(UserDict):
             except ValueError:
                 continue
 
-        job = {
+        attribute_to_values = {
             k: v if len(v) > 1 else v[0]
             for k, v in attribute_to_values.items()
         }
-
-        job["job_name"] = job['insert_job']
+        
+        job.update(attribute_to_values)
+        job.job_name = job['insert_job']
 
         return job

--- a/jilutil/auto_sys_job.py
+++ b/jilutil/auto_sys_job.py
@@ -91,8 +91,6 @@ class AutoSysJob(UserDict):
     def from_str(cls, jil: str):
         """Creates a new job from a string"""
         
-        NOTIFICATION_EMAILADDRESS = "notification_emailaddress"
-
         job = cls()
 
         # force job_type onto a new line
@@ -103,7 +101,7 @@ class AutoSysJob(UserDict):
         lines = [line.strip() for line in jil.split('\n') if line.strip() != '']
 
         multiline_comment_mode = False
-        email_address_list = []
+        attribute_to_values = {}
         for line in lines:
             # check if line is a comment
             if line.startswith('/*') or line.startswith('#'):
@@ -120,14 +118,15 @@ class AutoSysJob(UserDict):
             try:
                 # get the attribute:value pair
                 attribute, value = line.split(':', 1)
-                if attribute == NOTIFICATION_EMAILADDRESS:
-                    email_address_list.append(value)
-                else:
-                    job[attribute.strip()] = value.strip()
+                attribute_to_values.setdefault(attribute.strip(), []).append(value.strip())
             except ValueError:
                 continue
-            
-        job[NOTIFICATION_EMAILADDRESS] = email_address_list
-        job.job_name = job['insert_job']
+
+        job = {
+            k: v if len(v) > 1 else v[0]
+            for k, v in attribute_to_values.items()
+        }
+
+        job["job_name"] = job['insert_job']
 
         return job

--- a/jilutil/auto_sys_job.py
+++ b/jilutil/auto_sys_job.py
@@ -91,6 +91,8 @@ class AutoSysJob(UserDict):
     @classmethod
     def from_str(cls, jil: str):
         """Creates a new job from a string"""
+        
+        NOTIFICATION_EMAILADDRESS = "notification_emailaddress"
 
         job = cls()
 
@@ -102,6 +104,7 @@ class AutoSysJob(UserDict):
         lines = [line.strip() for line in jil.split('\n') if line.strip() != '']
 
         multiline_comment_mode = False
+        email_address_list = []
         for line in lines:
             # check if line is a comment
             if line.startswith('/*') or line.startswith('#'):
@@ -118,10 +121,14 @@ class AutoSysJob(UserDict):
             try:
                 # get the attribute:value pair
                 attribute, value = line.split(':', 1)
-                job[attribute.strip()] = value.strip()
+                if attribute == NOTIFICATION_EMAILADDRESS:
+                    email_address_list.append(value)
+                else:
+                    job[attribute.strip()] = value.strip()
             except ValueError:
                 continue
-
+            
+        job[NOTIFICATION_EMAILADDRESS] = email_address_list
         job.job_name = job['insert_job']
 
         return job


### PR DESCRIPTION
Adds a special case to handle jobs with multiple emails: 

Jobs with this format:
```
notification_emailaddress: email1@domain.com
notification_emailaddress: email2@domain.com
notification_emailaddress: email3@domain.com
notification_emailaddress: email4@domain.com
notification_emailaddress: email5@domain.com
```

Only got one email parsed (the last one). This PR appends them to an array.