### PR TITLE
remove starting/ending quotes in values

### DIFF
--- a/jilutil/__init__.py
+++ b/jilutil/__init__.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 
 from .jil_parser import JilParser
-from jilutil.auto_sys_job import AutoSysJob
+from .auto_sys_job import AutoSysJob
 
 verbose = False
 

--- a/jilutil/auto_sys_job.py
+++ b/jilutil/auto_sys_job.py
@@ -75,7 +75,7 @@ class AutoSysJob(UserDict):
         job_str = self.job_name_comment.format(atts['insert_job']) + '\n\n'
 
         # add special insert_job & job_type attributes
-        job_str += 'insert_job: {}'.format(atts['insert_job'])
+        job_str += 'insert_job: {}\n'.format(atts['insert_job'])
         del atts['insert_job']
 
         # iterate over attribute:value pairs in alphabetical order

--- a/jilutil/auto_sys_job.py
+++ b/jilutil/auto_sys_job.py
@@ -4,12 +4,12 @@ from collections import UserDict
 
 
 class AutoSysJob(UserDict):
-    r"""Regex pattern for matching job start comments
+    r"""Class that represents a job within AutoSys and its attributes
+
+    Regex pattern for matching job start line:
     >>> re.match(AutoSysJob.job_start_regex, 'insert_job: FOO\n\nbar: baz').group(1)
     'FOO'
     """
-
-    """Class that represents a job within AutoSys and its attributes"""
 
     default_attributes = {
         'insert_job': '',

--- a/jilutil/auto_sys_job.py
+++ b/jilutil/auto_sys_job.py
@@ -104,6 +104,8 @@ class AutoSysJob(UserDict):
         {'insert_job': 'TEST.ECHO', 'foo': "bar 'baz'", 'bop': 'qux'}
         >>> AutoSysJob.from_str('insert_job: TEST.ECHO \n foo: bar "baz" \n bop: "qux"')
         {'insert_job': 'TEST.ECHO', 'foo': 'bar "baz"', 'bop': 'qux'}
+        >>> AutoSysJob.from_str('''insert_job: TEST.ECHO \n foo: "bar" "baz" \n bop: "qux 'bonk'"''')
+        {'insert_job': 'TEST.ECHO', 'foo': '"bar" "baz"', 'bop': "qux 'bonk'"}
 
         ```
         """
@@ -141,7 +143,11 @@ class AutoSysJob(UserDict):
                 value = value.strip()
 
                 # remove single or double quotes if the whole string is wrapped with them
-                if isinstance(value, str) and value[0] in ('"', "'") and value[-1] in ('"', "'"):
+                if (
+                    isinstance(value, str)
+                    and (value[0] in ('"', "'") and value[-1] in ('"', "'"))
+                    and (value.count('"') == 2 or value.count("'") == 2)
+                ):
                     value = value[1:-1]
 
                 attribute_to_values.setdefault(attribute, []).append(value)

--- a/jilutil/auto_sys_job.py
+++ b/jilutil/auto_sys_job.py
@@ -100,7 +100,11 @@ class AutoSysJob(UserDict):
         {'insert_job': 'TEST.ECHO', 'job_type': 'BOX'}
         >>> AutoSysJob.from_str('insert_job: TEST.ECHO \n repeated_field: value \n repeated_field: value')
         {'insert_job': 'TEST.ECHO', 'repeated_field': ['value', 'value']}
-        
+        >>> AutoSysJob.from_str("insert_job: TEST.ECHO \n foo: bar 'baz' \n bop: 'qux'")
+        {'insert_job': 'TEST.ECHO', 'foo': "bar 'baz'", 'bop': 'qux'}
+        >>> AutoSysJob.from_str('insert_job: TEST.ECHO \n foo: bar "baz" \n bop: "qux"')
+        {'insert_job': 'TEST.ECHO', 'foo': 'bar "baz"', 'bop': 'qux'}
+
         ```
         """
         job = cls()
@@ -133,7 +137,14 @@ class AutoSysJob(UserDict):
             try:
                 # get the attribute:value pair
                 attribute, value = line.split(':', 1)
-                attribute_to_values.setdefault(attribute.strip(), []).append(value.strip())
+                attribute = attribute.strip()
+                value = value.strip()
+
+                # remove single or double quotes if the whole string is wrapped with them
+                if isinstance(value, str) and value[0] in ('"', "'") and value[-1] in ('"', "'"):
+                    value = value[1:-1]
+
+                attribute_to_values.setdefault(attribute, []).append(value)
             except ValueError:
                 continue
 
@@ -141,7 +152,7 @@ class AutoSysJob(UserDict):
             k: v if len(v) > 1 else v[0]
             for k, v in attribute_to_values.items()
         }
-        
+
         job.update(attribute_to_values)
         job.job_name = job['insert_job']
 

--- a/tests/test_auto_sys_job.py
+++ b/tests/test_auto_sys_job.py
@@ -2,12 +2,13 @@ from jilutil.auto_sys_job import AutoSysJob
 
 jil_box_job = """/* ----------------- SAMPLE_BOX_JOB ----------------- */
 
-insert_job: SAMPLE_BOX_JOB   job_type: BOX
+insert_job: SAMPLE_BOX_JOB
 alarm_if_fail: 1
 date_conditions: 1
 days_of_week: su,mo,tu,we,th,fr,sa
 description: "Sample box job"
 group: SOME_GROUP
+job_type: BOX
 owner: root@domain
 permission: gx,ge,wx,we,mx,me
 start_times: "20:00"
@@ -24,11 +25,11 @@ def test_from_str():
     assert job['alarm_if_fail'] == '1'
     assert job['date_conditions'] == '1'
     assert job['days_of_week'] == 'su,mo,tu,we,th,fr,sa'
-    assert job['description'] == '"Sample box job"'
+    assert job['description'] == 'Sample box job'
     assert job['group'] == 'SOME_GROUP'
     assert job['owner'] == 'root@domain'
     assert job['permission'] == 'gx,ge,wx,we,mx,me'
-    assert job['start_times'] == '"20:00"'
+    assert job['start_times'] == '20:00'
 
 def test_to_str():
 

--- a/tests/test_jil_parser.py
+++ b/tests/test_jil_parser.py
@@ -1,4 +1,4 @@
-from jil_parser import JilParser
+from jilutil.jil_parser import JilParser
 
 
 def test_jil_parser_parse_jobs_from_str(project_root):
@@ -31,7 +31,7 @@ def test_jil_parser_parse_jobs_from_str_one_dot_jil(project_root):
         'job_type': 'FT',
         'machine': 'ftagt',
         'owner': 'julian',
-        'watch_file': '"c:\\data\\monthly.log"',
+        'watch_file': r'c:\data\monthly.log',
         'watch_file_type': 'GENERATE',
         'watch_no_change': '2'
     }, {
@@ -39,7 +39,7 @@ def test_jil_parser_parse_jobs_from_str_one_dot_jil(project_root):
         'job_type': 'FW',
         'machine': 'winagent',
         'owner': 'julian',
-        'watch_file': '"c:\\tmp\\watch_file.log"',
+        'watch_file': r'c:\tmp\watch_file.log',
         'watch_file_min_size': '10000',
         'watch_interval': '90'
     }, {
@@ -64,7 +64,7 @@ def test_jil_parser_parse_jobs_from_str_two_dot_jil(project_root):
         'insert_job': 'prodbackup',
         'machine': 'prod1',
         'owner': 'root',
-        'start_times': '"22:00"',
+        'start_times': '22:00',
         'term_run_time': '600'
     }, {
         'command': '/root/backup.sh && curl -sm 30 k.wdt.io/123abc/backupdb',
@@ -73,7 +73,7 @@ def test_jil_parser_parse_jobs_from_str_two_dot_jil(project_root):
         'insert_job': 'prodbackup',
         'machine': 'prod1',
         'owner': 'root',
-        'start_times': '"22:00"',
+        'start_times': '22:00',
         'term_run_time': '600'
     }]}
 
@@ -87,7 +87,7 @@ def test_jil_parser_parse_jobs_from_str_three_dot_jil(project_root):
         'command': '/path/to/watch_done_file.sh',
         'date_conditions': 'y',
         'days_of_week': 'all',
-        'description': '"Watch for .done file arrival"',
+        'description': 'Watch for .done file arrival',
         'insert_job': 'WATCH_DONE_FILE',
         'job_type': 'CMD',
         'machine': 'hostname',
@@ -95,7 +95,7 @@ def test_jil_parser_parse_jobs_from_str_three_dot_jil(project_root):
         'owner': 'autosys_user',
         'permission': 'gx,ge,wx',
         'profile': '/home/autosys_user/.profile',
-        'start_times': '"00:00"',
+        'start_times': '00:00',
         'std_err_file': '/path/to/logs/WATCH_DONE_FILE.err',
         'std_out_file': '/path/to/logs/WATCH_DONE_FILE.out'
     }]}


### PR DESCRIPTION
Remove `"` and `'`, if at both start and end of string. 
Ignore any in the middle

`'foo'` -> `foo`

~~[!WARNING] this could malform a string like `'foo' 'bar'` - but that feels like enough of an edge case?~~
~~edit:// nope - the edge case happens a bunch :(~~
edit:// resolved!